### PR TITLE
Update log4j to 2.17 to address CVE-2021-45105.

### DIFF
--- a/META-INF/maven/log4j/log4j/pom.xml
+++ b/META-INF/maven/log4j/log4j/pom.xml
@@ -32,7 +32,7 @@ target platform and specify -Dntdll_target=msbuild on the mvn command line.
   <artifactId>log4j</artifactId>
   <packaging>bundle</packaging>
   <name>Apache Log4j</name>
-  <version>1.2.17</version>
+  <version>2.17.0</version>
   <description>Apache Log4j 1.2</description>
   <url>http://logging.apache.org/log4j/1.2/</url>
   <issueManagement>


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105